### PR TITLE
feat: add profile routing and guards

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -11,8 +11,8 @@ export default {
 </script>
 
 <style lang="sass" scoped>
-.test 
-  border: 1px solid 
-#ok 
+.test
+  border: 1px solid
+#ok
   color: red
 </style>

--- a/src/pages/Profile.vue
+++ b/src/pages/Profile.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
     <h1>Profile Page</h1>
+    <router-link :to="'/profile/' + $auth.currentUser.uid ">My Profile</router-link>
+    <router-view></router-view>
   </div>
 </template>
 

--- a/src/pages/Profile.vue
+++ b/src/pages/Profile.vue
@@ -1,14 +1,18 @@
 <template>
   <div>
     <h1>Profile Page</h1>
-    <router-link :to="'/profile/' + $auth.currentUser.uid ">My Profile</router-link>
+    <router-link :to="`/profile/${currentUser.uid}`">My Profile</router-link>
     <router-view></router-view>
   </div>
 </template>
 
 <script>
 export default {
-
+  computed: {
+    currentUser () {
+      return this.$store.getters.currentUser
+    },
+  },
 }
 </script>
 

--- a/src/pages/Profile.vue
+++ b/src/pages/Profile.vue
@@ -7,11 +7,13 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   computed: {
-    currentUser () {
-      return this.$store.getters.currentUser
-    },
+    ...mapGetters([
+      'currentUser',
+    ]),
   },
 }
 </script>

--- a/src/pages/ProfileDetail.vue
+++ b/src/pages/ProfileDetail.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <h1>Profile Details Page</h1>
+    <p>User Id {{$route.params.id}}</p>
+    <router-link :to="'/profile/' + $route.params.id + '/edit' " tag="button" type="button" class="button is-primary" name="button">Edit</router-link>
+
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style lang="sass" scoped>
+</style>

--- a/src/pages/ProfileDetail.vue
+++ b/src/pages/ProfileDetail.vue
@@ -2,7 +2,7 @@
   <div>
     <h1>Profile Details Page</h1>
     <p>User Id {{$route.params.id}}</p>
-    <router-link :to="'/profile/' + $route.params.id + '/edit' " tag="button" type="button" class="button is-primary" name="button">Edit</router-link>
+    <router-link :to="`/profile/${$route.params.id}/edit`" tag="button" type="button" class="button is-primary" name="button">Edit</router-link>
 
   </div>
 </template>

--- a/src/pages/ProfileEdit.vue
+++ b/src/pages/ProfileEdit.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <h1>Profile Edit Page</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style lang="sass" scoped>
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,8 @@ import Home from '@/pages/Home'
 import Login from '@/pages/Login'
 import Signup from '@/pages/Signup'
 import Profile from '@/pages/Profile'
+import ProfileDetail from '@/pages/ProfileDetail'
+import ProfileEdit from '@/pages/ProfileEdit'
 import Messages from '@/pages/Messages'
 import Projects from '@/pages/Projects'
 import Secret from '@/pages/Secret'
@@ -38,8 +40,27 @@ let router = new Router({
     },
     {
       path: '/profile',
-      name: 'Home',
+      name: 'Profile',
       component: Profile,
+      meta: {
+        requiresAuth: true,
+      },
+      children: [
+        { path: ':id', component: ProfileDetail },
+        {
+          path: ':id/edit',
+          component: ProfileEdit,
+          beforeEnter (to, from, next) {
+            const routeId = to.params.id
+            const currentUser = Auth.auth.currentUser
+            if (routeId !== currentUser.uid) {
+              next(`/profile/${routeId}`)
+            } else {
+              next()
+            }
+          },
+        },
+      ],
     },
     {
       path: '/messages',
@@ -55,7 +76,7 @@ let router = new Router({
 })
 
 router.beforeEach((to, from, next) => {
-  let currentUser = Auth.auth.currentUser
+  const currentUser = Auth.auth.currentUser
   let requiresAuth = to.matched.some(record => record.meta.requiresAuth)
   if (requiresAuth && !currentUser) {
     console.log('no user logged in')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -51,12 +51,12 @@ let router = new Router({
           path: ':id/edit',
           component: ProfileEdit,
           beforeEnter (to, from, next) {
-            const routeId = to.params.id
+            const userId = to.params.id
             const currentUser = Auth.auth.currentUser
-            if (routeId !== currentUser.uid) {
-              next(`/profile/${routeId}`)
+            if (userId !== currentUser.uid) {
+              return next(`/profile/${userId}`)
             } else {
-              next()
+              return next()
             }
           },
         },
@@ -77,13 +77,12 @@ let router = new Router({
 
 router.beforeEach((to, from, next) => {
   const currentUser = Auth.auth.currentUser
-  let requiresAuth = to.matched.some(record => record.meta.requiresAuth)
+  const requiresAuth = to.matched.some(record => record.meta.requiresAuth)
   if (requiresAuth && !currentUser) {
-    console.log('no user logged in')
-    next('login')
+    return next('login')
   } else {
     // no auth required
-    next()
+    return next()
   }
 })
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -55,9 +55,8 @@ let router = new Router({
             const currentUser = Auth.auth.currentUser
             if (userId !== currentUser.uid) {
               return next(`/profile/${userId}`)
-            } else {
-              return next()
             }
+            return next()
           },
         },
       ],


### PR DESCRIPTION
Set up profile page guard and protection for nested edit page. 

Profile landing page can only be accessed to logged in user.
Logged in user can access any profile via /profile/:id (eventually remove the edit button if current user !== params.id)
Logged in user can only access their own edit page (beforeEnter guard) via /profile/:id/edit otherwise redirected to /profile/:id

So far only a skeleton set up, as I want to make sure the routing is how we want it before we start adding functionality.   Should the sub components such as ProfileDetails and ProfileEdit go in a separate directory?  